### PR TITLE
Update video links to `data-knowledge-hub_videos` repository

### DIFF
--- a/docs/docs/00_background-rationale.mdx
+++ b/docs/docs/00_background-rationale.mdx
@@ -31,8 +31,8 @@ import VideoCard from "../src/components/VideoCard.js";
 The Data Knowledge Hub for Researching Online Discourse (Data Knowledge Hub) is an initiative that aims to provide a central resource for researchers, social scientists, data scientists, journalists, and other practitioners, and policy makers interested in monitoring social media and online discourse more broadly.
 
 <VideoCard
-  videoSrc={require("@site/static/video/UPDEM_Editorial_540.mp4").default}
-  thumbnailSrc={require("@site/static/video/UPDEM_Editorial_540.png").default}
+  videoSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/videos/UPDEM_Editorial_540.mp4"
+  thumbnailSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/thumbnails/UPDEM_Editorial_540.png"
 ></VideoCard>
 
 ### Why do we feel this is necessary?

--- a/docs/docs/01_get-started/01_03_legal-considerations.mdx
+++ b/docs/docs/01_get-started/01_03_legal-considerations.mdx
@@ -20,8 +20,8 @@ import VideoCard from "../../src/components/VideoCard.js";
 ></AuthorCard>
 
 <VideoCard
-  videoSrc={require("@site/static/video/UPDEM_Polidoro_540.mp4").default}
-  thumbnailSrc={require("@site/static/video/UPDEM_Polidoro_540.png").default}
+  videoSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/videos/UPDEM_Polidoro_540.mp4"
+  thumbnailSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/thumbnails/UPDEM_Polidoro_540.png"
 ></VideoCard>
 
 In today's digital world, there is a growing demand for big online platforms to be more transparent and accountable. Researchers, journalists, human rights advocates, governments and users all want to know what these platforms are up to. Even businesses, content creators and public figures who rely on these platforms struggle to understand how they work because these entities are owned by big private companies that often keep their operations hidden and benefit from information asymmetry.

--- a/docs/docs/02_data-access/02_02_overview-access.mdx
+++ b/docs/docs/02_data-access/02_02_overview-access.mdx
@@ -26,8 +26,8 @@ _with contributions from Richard Kuchta, Bea Saab, and Lena-Maria Boswald_
 
 
 <VideoCard
-  videoSrc={require("@site/static/video/UPDEM_Thompson_540.mp4").default}
-  thumbnailSrc={require("@site/static/video/UPDEM_Thompson_540.png").default}
+  videoSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/videos/UPDEM_Thompson_540.mp4"
+  thumbnailSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/thumbnails/UPDEM_Thompson_540.png"
 ></VideoCard>
 
 ## Introduction: A matter of access

--- a/docs/docs/03_data-collection/03_00_code-samples/twitter/index.mdx
+++ b/docs/docs/03_data-collection/03_00_code-samples/twitter/index.mdx
@@ -42,8 +42,8 @@ import LanguageChip from "@site/src/components/LanguageChip.js";
 ></AuthorCard>
 
 <VideoCard
-  videoSrc={require("@site/static/video/UPDEM_Neumeier_540.mp4").default}
-  thumbnailSrc={require("@site/static/video/UPDEM_Neumeier_540.png").default}
+  videoSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/videos/UPDEM_Neumeier_540.mp4"
+  thumbnailSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/thumbnails/UPDEM_Neumeier_540.png"
 ></VideoCard>
 
 Social media platforms have gained significant importance in recent years due to their extensive reach and high usage. They provide researchers in various fields with valuable insights into public, social, and political areas, making them an essential data source. When it comes to X (formerly Twitter) and its data gathering, specific features exist, which we discuss in the following documents.

--- a/docs/docs/03_data-collection/03_00_code-samples/web-scraping-intro.mdx
+++ b/docs/docs/03_data-collection/03_00_code-samples/web-scraping-intro.mdx
@@ -25,8 +25,8 @@ import PlatformChip from "../../../src/components/PlatformChip.js";
 ></AuthorCard>
 
 <VideoCard
-  videoSrc={require("@site/static/video/UPDEM_Holnburger_540.mp4").default}
-  thumbnailSrc={require("@site/static/video/UPDEM_Holnburger_540.png").default}
+  videoSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/videos/UPDEM_Holnburger_540.mp4"
+  thumbnailSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/thumbnails/UPDEM_Holnburger_540.png"
 ></VideoCard>
 
 ## Current challenges of webscraping

--- a/docs/docs/03_data-collection/03_02_data-collection-methods.mdx
+++ b/docs/docs/03_data-collection/03_02_data-collection-methods.mdx
@@ -17,8 +17,8 @@ import VideoCard from "../../src/components/VideoCard.js";
 ></AuthorCard>
 
 <VideoCard
-  videoSrc={require("@site/static/video/UPDEM_Degeling_540.mp4").default}
-  thumbnailSrc={require("@site/static/video/UPDEM_Degeling_540.png").default}
+  videoSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/videos/UPDEM_Degeling_540.mp4"
+  thumbnailSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/thumbnails/UPDEM_Degeling_540.png"
 ></VideoCard>
 
 There are always multiple ways to audit an online platform. Depending on the question you want to answer, one or more approaches can lead to insights about (data) practices of a social media platform. In the following chapter, you will find an overview of common data collection methods – all of which we have leveraged to better understand the practices of TikTok. The chapter is based on our work on [auditing recommender systems](https://www.stiftung-nv.de/de/publication/auditing-recommender-systems#step3-types-if-algo-audits).

--- a/docs/docs/04_data-analysis/04_00_code-samples/hashtag-analysis.mdx
+++ b/docs/docs/04_data-analysis/04_00_code-samples/hashtag-analysis.mdx
@@ -24,8 +24,8 @@ import LanguageChip from "../../../src/components/LanguageChip.js";
 ></AuthorCard>
 
 <VideoCard
-  videoSrc={require("@site/static/video/UPDEM_Degeling_540.mp4").default}
-  thumbnailSrc={require("@site/static/video/UPDEM_Degeling_540.png").default}
+  videoSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/videos/UPDEM_Degeling_540.mp4"
+  thumbnailSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/thumbnails/UPDEM_Degeling_540.png"
 ></VideoCard>
 
 In this chapter you will learn about the different steps necessary to conduct a hashtag analysis on TikTok that can result in a visualization like this: [Hashtag Analysis by Week](https://martin.degeling.com/snv/fyp-hashtags-by-week/)

--- a/docs/docs/04_data-analysis/04_00_code-samples/social-network-analysis.mdx
+++ b/docs/docs/04_data-analysis/04_00_code-samples/social-network-analysis.mdx
@@ -25,8 +25,8 @@ import LanguageChip from "../../../src/components/LanguageChip.js";
 ></AuthorCard>
 
 <VideoCard
-  videoSrc={require("@site/static/video/UPDEM_Darius_540.mp4").default}
-  thumbnailSrc={require("@site/static/video/UPDEM_Darius_540.png").default}
+  videoSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/videos/UPDEM_Darius_540.mp4"
+  thumbnailSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/thumbnails/UPDEM_Darius_540.png"
 ></VideoCard>
 
 This chapter is an introductory tutorial to the broad field of social network analysis. The tutorial includes an example of how to use social network analysis to detect communities in online debates on social platforms like X (Twitter). In the given example you’ll learn how to assess a sample of X (Twitter) users retweeting messages using #Vaccination during the Covid-19 pandemic. During the Covid-19 pandemic #Vaccination was also used by accounts that amplified conspiracy narratives and health misinformation about vaccines. The network analysis approach illustrates how to identify communities of users that are more likely to amplify dis- and/or misinformation by combining community-detection algorithms with qualitative content analysis of identified communities.

--- a/docs/docs/05_literature/05_02_literature-overview.mdx
+++ b/docs/docs/05_literature/05_02_literature-overview.mdx
@@ -18,8 +18,8 @@ import VideoCard from "../../src/components/VideoCard.js";
 ></AuthorCard>
 
 <VideoCard
-  videoSrc={require("@site/static/video/UPDEM_Abels_540.mp4").default}
-  thumbnailSrc={require("@site/static/video/UPDEM_Abels_540.png").default}
+  videoSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/videos/UPDEM_Abels_540.mp4"
+  thumbnailSrc="https://github.com/bertelsmannstift/data-knowledge-hub_videos/raw/main/thumbnails/UPDEM_Abels_540.png"
 ></VideoCard>
 
 This chapter builds on a scoping review of:


### PR DESCRIPTION
# Pull Request Title
Update video links to `data-knowledge-hub_videos` repository
 
## Description

These changes update all the video links and thumbnails to their new home, over in the [`data-knowledge-hub_videos`](https://github.com/bertelsmannstift/data-knowledge-hub_videos) repository. This prepares for the removal of the videos in this repo (and the entire history) to reduce the project size. The removal of the videos will helps to make the project more manageable and easier to contribute to.

I tested it locally with all the changes and it worked that way. Specifically, I ran (from within `docs/`):

```
npm install
npm start
``` 
 
## Checklist
 
- [x] I agree to the Code of Conduct.
- [x] My contribution follows the project's coding style guidelines.
