### PR TITLE
Add automated deployments of `main` branch to github pages

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Install dependencies
+      run: |
+        cd docs
+        npm install
+
+    - name: Build the project
+      run: |
+        cd docs
+        npm run build
+
+    - name: Deploy to GitHub Pages
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git checkout --orphan gh-pages
+        git --work-tree=docs/build add --all
+        git --work-tree=docs/build commit -m 'Deploy to GitHub Pages'
+        git push origin HEAD:gh-pages --force
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -7,7 +7,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
   title: 'Data Knowledge Hub for Monitoring Online Discourse',
   tagline: "The Data Knowledge Hub for Monitoring Online Discourse (Data Knowledge Hub) is an initiative that aims to provide a central resource for researchers, social scientists, data scientists, journalists, practitioners, and policy makers interested in monitoring social media and online discourse more broadly.",
   url: 'https://www.data-knowledge-hub.com',
-  baseUrl: '/',
+  baseUrl: '/data-knowledge-hub/',
   customFields: {
     staticDirectories: ['static'], 
   },


### PR DESCRIPTION
# Pull Request Title
Add automated deployments of `main` branch to github pages
 
## Description

This pull request adds an automation to build the static pages for the Data Knowledge Hub, and commits these to the `gh-pages` branch. This happens **every time** the `main` branch is updated.

The `gh-pages` branch can be used to deploy the website using GitHub pages. I tried this out in my own fork, which you can see on this URL to confirm it works: https://chartgerink.github.io/data-knowledge-hub/

For GitHub pages, I used  these settings:

![CleanShot 2024-09-29 at 09 10 12@2x](https://github.com/user-attachments/assets/8311c86a-8dbc-45ab-bafa-044b337081e5)

If this is merged and there are any issues, I am available to help debug. 😊
 
## Related Issue

Closes #1.
 
## Checklist
 
- [x] I agree to the Code of Conduct.
- [x] My contribution follows the project's coding style guidelines.
