### PR TITLE
Write out CNAME as part of the github pages workflow

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -27,6 +27,7 @@ jobs:
       run: |
         cd docs
         npm run build
+        echo data-knowledge-hub.com > build/CNAME
 
     - name: Deploy to GitHub Pages
       run: |


### PR DESCRIPTION
# Pull Request Title

Write out CNAME as part of the github pages workflow
 
## Description

This ensures that the GitHub pages auto-deployment does not forget the domain name it is connected to (`data-knowledge-hub.com`), like a goldfish!

## Related Issue
<!-- If this PR addresses or fixes an issue, link it here: -->

None. 
 
## Checklist
 
- [x] I agree to the Code of Conduct.
- [x] My contribution follows the project's coding style guidelines.
