### PR TITLE
Update docusaurus config for domain change

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -7,7 +7,7 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
   title: 'Data Knowledge Hub for Researching Online Discourse',
   tagline: "The Data Knowledge Hub for Researching Online Discourse (Data Knowledge Hub) is an initiative that aims to provide a central resource for researchers, social scientists, data scientists, journalists, practitioners, and policymakers interested in independently researching social media and online discourse more broadly.",
   url: 'https://www.data-knowledge-hub.com',
-  baseUrl: '/data-knowledge-hub/',
+  baseUrl: '/',
   customFields: {
     staticDirectories: ['static'], 
   },


### PR DESCRIPTION
# Pull Request Title
Update docusaurus config for domain change
 
## Description

The Data Knowledge Hub is now being built from the github pages here 😊 It also means the docusaurus config needs to be updated to the correct domain (that is, `/` instead of `/data-knowledge-hub`).

It currently gives this error, which should be fixed by the proposed change. Of course, we will only know 100% once we make the change, and I remain available to debug on short notice 😊
 
![CleanShot 2024-10-02 at 08 36 59@2x](https://github.com/user-attachments/assets/498f2f84-068d-418f-8eb5-12bd5950b277)

## Related Issue
<!-- If this PR addresses or fixes an issue, link it here: -->
 
None
 
 
## Checklist
 
- [x] I agree to the Code of Conduct.
- [x] My contribution follows the project's coding style guidelines.
